### PR TITLE
Wraps returns in the result field

### DIFF
--- a/codegen/src/main/kotlin/org/web3j/openapi/codegen/servergen/subgenerators/ResourcesImplGenerator.kt
+++ b/codegen/src/main/kotlin/org/web3j/openapi/codegen/servergen/subgenerators/ResourcesImplGenerator.kt
@@ -202,7 +202,7 @@ internal class ResourcesImplGenerator(
         return callParameters.removeSuffix(",")
     }
 
-    private fun eventsImports(): List<Import> {
+    private fun eventImports(): List<Import> {
         return resourcesDefinition
             .filter { it.type == "event" }
             .map { abiDefinition ->
@@ -230,7 +230,7 @@ internal class ResourcesImplGenerator(
         context["decapitalizedContractName"] = contractName.decapitalize()
         context["capitalizedContractName"] = contractName.capitalize()
         context["EventResource"] = eventsResources()
-        context["eventsImports"] = eventsImports()
+        context["eventImports"] = eventImports()
 
         val contractFolder = File(
             Path.of(

--- a/codegen/src/main/kotlin/org/web3j/openapi/codegen/servergen/subgenerators/ResourcesImplGenerator.kt
+++ b/codegen/src/main/kotlin/org/web3j/openapi/codegen/servergen/subgenerators/ResourcesImplGenerator.kt
@@ -160,8 +160,8 @@ internal class ResourcesImplGenerator(
             val innerType = returnType.substringAfter("<").removeSuffix(">")
             when {
                 innerType.startsWith("org.web3j.tuples") -> wrapTuplesCode(code, innerType)
-                innerType.contains("StructModel") -> "return org.web3j.openapi.core.models.PrimitivesModel($code.toModel())"
-                else -> "return org.web3j.openapi.core.models.PrimitivesModel($code)"
+                innerType.contains("StructModel") -> "return org.web3j.openapi.core.models.ResultModel($code.toModel())"
+                else -> "return org.web3j.openapi.core.models.ResultModel($code)"
             }
         }
     }
@@ -182,7 +182,7 @@ internal class ResourcesImplGenerator(
         }.joinToString(",")
 
         return """val ($variableNames) = $code
-                return org.web3j.openapi.core.models.PrimitivesModel(
+                return org.web3j.openapi.core.models.ResultModel(
                     Tuple${components.size}($tupleConstructor)
                 )""".trimMargin()
     }

--- a/codegen/src/main/kotlin/org/web3j/openapi/codegen/servergen/subgenerators/ResourcesImplGenerator.kt
+++ b/codegen/src/main/kotlin/org/web3j/openapi/codegen/servergen/subgenerators/ResourcesImplGenerator.kt
@@ -159,9 +159,9 @@ internal class ResourcesImplGenerator(
         else {
             val innerType = returnType.substringAfter("<").removeSuffix(">")
             when {
-                innerType.startsWith("org.web3j.tuples") ->  wrapTuplesCode(code, innerType)
+                innerType.startsWith("org.web3j.tuples") -> wrapTuplesCode(code, innerType)
                 innerType.contains("StructModel") -> "return org.web3j.openapi.core.models.PrimitivesModel($code.toModel())"
-                else -> "return org.web3j.openapi.core.models.PrimitivesModel(${code})"
+                else -> "return org.web3j.openapi.core.models.PrimitivesModel($code)"
             }
         }
     }

--- a/codegen/src/main/kotlin/org/web3j/openapi/codegen/utils/KPoetUtils.kt
+++ b/codegen/src/main/kotlin/org/web3j/openapi/codegen/utils/KPoetUtils.kt
@@ -42,8 +42,8 @@ internal fun List<NamedType>.toDataClass(
     forEachIndexed { index, input ->
         val inputName = GeneratorUtils.argumentName(input.name, index)
         val inputType =
-            if (input.type == "tuple") input.type.toNativeType(true, input.internalType.structName, basePackageName, contractName.toLowerCase())
-            else input.type.toNativeType()
+            if (input.type == "tuple") input.type.mapType(true, input.internalType.structName, basePackageName, contractName.toLowerCase())
+            else input.type.mapType()
 
         constructorBuilder.addParameter(
             inputName,

--- a/codegen/src/main/kotlin/org/web3j/openapi/codegen/utils/SolidityUtils.kt
+++ b/codegen/src/main/kotlin/org/web3j/openapi/codegen/utils/SolidityUtils.kt
@@ -18,7 +18,6 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.plusParameter
 import com.squareup.kotlinpoet.TypeName
-import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import org.web3j.protocol.core.methods.response.AbiDefinition
 import java.io.File
@@ -28,35 +27,34 @@ import java.util.Comparator
 import java.util.HashMap
 import java.util.LinkedHashMap
 import java.util.stream.Collectors
-import kotlin.reflect.KClass
 
-internal fun String.toNativeType(isParameter: Boolean = true, structName: String = "", packageName: String = "", contractName: String = ""): TypeName {
+internal fun String.mapType(isParameter: Boolean = true, structName: String = "", packageName: String = "", contractName: String = ""): TypeName {
     return if (this == "address" || this == "string") {
-        getParameterMapping(isParameter, String::class)
+        getParameterMapping(isParameter, String::class.asTypeName())
     } else if (this == "int") {
-        getParameterMapping(isParameter, Integer::class)
+        getParameterMapping(isParameter, Integer::class.asTypeName())
     } else if (endsWith("]")) {
-        toNativeArrayType(isParameter)
+        getParameterMapping(isParameter, toNativeArrayType(isParameter))
     } else if (startsWith("uint") || startsWith("int")) {
         getNumbersMapping(isParameter, this)
     } else if (this == "byte") {
-        getParameterMapping(isParameter, Byte::class)
+        getParameterMapping(isParameter, Byte::class.asTypeName())
     } else if (startsWith("bytes") || this == "dynamicbytes") {
-        getParameterMapping(isParameter, ByteArray::class)
+        getParameterMapping(isParameter, ByteArray::class.asTypeName())
     } else if (this == "bool" || this == "boolean") {
-        getParameterMapping(isParameter, Boolean::class)
+        getParameterMapping(isParameter, Boolean::class.asTypeName())
     } else if (toLowerCase() == "float") {
-        getParameterMapping(isParameter, Float::class)
+        getParameterMapping(isParameter, Float::class.asTypeName())
     } else if (toLowerCase() == "double") {
-        getParameterMapping(isParameter, Double::class)
+        getParameterMapping(isParameter, Double::class.asTypeName())
     } else if (toLowerCase() == "short") {
-        getParameterMapping(isParameter, Short::class)
+        getParameterMapping(isParameter, Short::class.asTypeName())
     } else if (toLowerCase() == "long") {
-        getParameterMapping(isParameter, Long::class)
+        getParameterMapping(isParameter, Long::class.asTypeName())
     } else if (toLowerCase() == "char") {
-        getParameterMapping(isParameter, Character::class)
+        getParameterMapping(isParameter, Character::class.asTypeName())
     } else if (toLowerCase() == "tuple") {
-        ClassName("$packageName.core.$contractName.model", "${structName}StructModel")
+        getParameterMapping(isParameter, ClassName("$packageName.core.$contractName.model", "${structName}StructModel"))
     } else {
         throw UnsupportedOperationException(
             "Unsupported type: $this, no native type mapping exists."
@@ -65,33 +63,33 @@ internal fun String.toNativeType(isParameter: Boolean = true, structName: String
 }
 
 fun getNumbersMapping(isParameter: Boolean, type: String): TypeName {
-    return if (isParameter) getParameterMapping(isParameter, BigInteger::class)
-    else if (type == "uint8") getParameterMapping(isParameter, BigInteger::class) // FIXME: remove this when web3j-codegen fixes this problem
+    return if (isParameter) getParameterMapping(isParameter, BigInteger::class.asTypeName())
+    else if (type == "uint8") getParameterMapping(isParameter, BigInteger::class.asTypeName()) // FIXME: remove this when web3j-codegen fixes this problem
     else if (type.startsWith("int") && type.substringAfter("int").toInt() < 16 ||
             type.startsWith("uint") && type.substringAfter("int").toInt() < 16)
-        getParameterMapping(isParameter, Short::class)
+        getParameterMapping(isParameter, Short::class.asTypeName())
     else if (type.startsWith("int") && type.substringAfter("int").toInt() <= 32 ||
             type.startsWith("uint") && type.substringAfter("int").toInt() < 32)
-        getParameterMapping(isParameter, Integer::class)
+        getParameterMapping(isParameter, Integer::class.asTypeName())
     else if (type.startsWith("int") && type.substringAfter("int").toInt() <= 64 ||
             type.startsWith("uint") && type.substringAfter("int").toInt() < 64)
-        getParameterMapping(isParameter, Long::class)
+        getParameterMapping(isParameter, Long::class.asTypeName())
     else
-        getParameterMapping(isParameter, BigInteger::class)
+        getParameterMapping(isParameter, BigInteger::class.asTypeName())
 }
 
-private fun getParameterMapping(isParameter: Boolean, kClass: KClass<*>): TypeName {
-    return if (isParameter) kClass.asTypeName()
+private fun getParameterMapping(isParameter: Boolean, typeName: TypeName): TypeName {
+    return if (isParameter) typeName
     else {
         ClassName("org.web3j.openapi.core.models", "PrimitivesModel")
-            .parameterizedBy(kClass.asClassName())
+            .parameterizedBy(typeName)
     }
 }
 
 private fun String.toNativeArrayType(isParameter: Boolean, structName: String = "", packageName: String = "", contractName: String = ""): TypeName {
     return if (isParameter) {
         ClassName("kotlin.collections", "List")
-            .plusParameter(substringBeforeLast("[").toNativeType(isParameter, structName, packageName, contractName))
+            .plusParameter(substringBeforeLast("[").mapType(isParameter, structName, packageName, contractName))
     } else {
         ClassName("kotlin.collections", "List")
             .plusParameter(ANY.copy(true)).copy(true)
@@ -101,10 +99,12 @@ private fun String.toNativeArrayType(isParameter: Boolean, structName: String = 
 internal fun AbiDefinition.getReturnType(packageName: String = "", contractName: String = ""): TypeName {
     return if (!isTransactional()) {
         if (outputs.size == 1) {
-            outputs.first().type.toNativeType(false, outputs.first().internalType.structName, packageName, contractName)
+            outputs.first().type.mapType(false, outputs.first().internalType.structName, packageName, contractName)
         } else {
-            ClassName("org.web3j.tuples.generated", "Tuple${outputs.size}")
-                .parameterizedBy(outputs.map { it.type.toNativeType(true, it.internalType.structName, packageName, contractName).copy() })
+            getParameterMapping(
+                false,
+                ClassName("org.web3j.tuples.generated", "Tuple${outputs.size}")
+                    .parameterizedBy(outputs.map { it.type.mapType(true, it.internalType.structName, packageName, contractName).copy() }))
         }
     } else {
         ClassName("org.web3j.openapi.core.models", "TransactionReceiptModel")

--- a/codegen/src/main/kotlin/org/web3j/openapi/codegen/utils/SolidityUtils.kt
+++ b/codegen/src/main/kotlin/org/web3j/openapi/codegen/utils/SolidityUtils.kt
@@ -81,7 +81,7 @@ fun getNumbersMapping(isParameter: Boolean, type: String): TypeName {
 private fun getParameterMapping(isParameter: Boolean, typeName: TypeName): TypeName {
     return if (isParameter) typeName
     else {
-        ClassName("org.web3j.openapi.core.models", "PrimitivesModel")
+        ClassName("org.web3j.openapi.core.models", "ResultModel")
             .parameterizedBy(typeName)
     }
 }

--- a/codegen/src/main/resources/server/build.gradle.mustache
+++ b/codegen/src/main/resources/server/build.gradle.mustache
@@ -11,8 +11,7 @@ dependencies {
     implementation project(':{{rootProjectName}}-core')
 
     implementation "org.web3j.openapi:web3j-openapi-server:{{version}}"
-    implementation "org.web3j.openapi:web3j-openapi-console:{{version}}"
-    
+
     implementation "org.glassfish.jersey.containers:jersey-container-servlet:${versions.jersey}"
     
     swaggerUI 'org.webjars:swagger-ui:3.10.0'

--- a/codegen/src/test/kotlin/org/web3j/openapi/codegen/utils/SolidityUtilsTest.kt
+++ b/codegen/src/test/kotlin/org/web3j/openapi/codegen/utils/SolidityUtilsTest.kt
@@ -32,7 +32,7 @@ class SolidityUtilsTest {
                 ClassName("kotlin.collections", "List")
                     .plusParameter(Integer::class.asClassName())
             )
-        val actualResult = "int[10][20]".toNativeType()
+        val actualResult = "int[10][20]".mapType()
 
         assertThat(actualResult).isEqualTo(expectedResult)
     }
@@ -43,7 +43,7 @@ class SolidityUtilsTest {
             .plusParameter(ANY.copy(true))
             .copy(true)
 
-        val actualResult = "int[10][20]".toNativeType(false)
+        val actualResult = "int[10][20]".mapType(false)
 
         assertThat(actualResult).isEqualTo(expectedResult)
     }

--- a/codegen/src/test/kotlin/org/web3j/openapi/codegen/utils/SolidityUtilsTest.kt
+++ b/codegen/src/test/kotlin/org/web3j/openapi/codegen/utils/SolidityUtilsTest.kt
@@ -39,9 +39,12 @@ class SolidityUtilsTest {
 
     @Test
     fun `toNativeArrayType for returns`() {
-        val expectedResult = ClassName("kotlin.collections", "List")
-            .plusParameter(ANY.copy(true))
-            .copy(true)
+        val expectedResult = ClassName("org.web3j.openapi.core.models", "PrimitivesModel")
+            .parameterizedBy(
+                ClassName("kotlin.collections", "List")
+                    .plusParameter(ANY.copy(true))
+                    .copy(true)
+            )
 
         val actualResult = "int[10][20]".mapType(false)
 
@@ -75,12 +78,15 @@ class SolidityUtilsTest {
 
     @Test
     fun getMultipleFunctionReturnTypeTest() {
-        val expectedResult = ClassName("org.web3j.tuples.generated", "Tuple2")
+        val expectedResult = ClassName("org.web3j.openapi.core.models", "PrimitivesModel")
             .parameterizedBy(
-                listOf(
-                    Integer::class.asClassName(),
-                    String::class.asClassName()
-                )
+                ClassName("org.web3j.tuples.generated", "Tuple2")
+                    .parameterizedBy(
+                        listOf(
+                            Integer::class.asClassName(),
+                            String::class.asClassName()
+                        )
+                    )
             )
 
         val actualResult = AbiDefinition().apply {

--- a/codegen/src/test/kotlin/org/web3j/openapi/codegen/utils/SolidityUtilsTest.kt
+++ b/codegen/src/test/kotlin/org/web3j/openapi/codegen/utils/SolidityUtilsTest.kt
@@ -39,7 +39,7 @@ class SolidityUtilsTest {
 
     @Test
     fun `toNativeArrayType for returns`() {
-        val expectedResult = ClassName("org.web3j.openapi.core.models", "PrimitivesModel")
+        val expectedResult = ClassName("org.web3j.openapi.core.models", "ResultModel")
             .parameterizedBy(
                 ClassName("kotlin.collections", "List")
                     .plusParameter(ANY.copy(true))
@@ -52,8 +52,8 @@ class SolidityUtilsTest {
     }
 
     @Test
-    fun `getFunctionReturnType for PrimitivesModel`() {
-        val expectedResult = ClassName("org.web3j.openapi.core.models", "PrimitivesModel")
+    fun `getFunctionReturnType for ResultModel`() {
+        val expectedResult = ClassName("org.web3j.openapi.core.models", "ResultModel")
             .parameterizedBy(String::class.asClassName())
 
         val actualResult = AbiDefinition().apply {
@@ -78,7 +78,7 @@ class SolidityUtilsTest {
 
     @Test
     fun getMultipleFunctionReturnTypeTest() {
-        val expectedResult = ClassName("org.web3j.openapi.core.models", "PrimitivesModel")
+        val expectedResult = ClassName("org.web3j.openapi.core.models", "ResultModel")
             .parameterizedBy(
                 ClassName("org.web3j.tuples.generated", "Tuple2")
                     .parameterizedBy(

--- a/core/src/main/kotlin/org/web3j/openapi/core/models/PrimitivesModel.kt
+++ b/core/src/main/kotlin/org/web3j/openapi/core/models/PrimitivesModel.kt
@@ -12,6 +12,9 @@
  */
 package org.web3j.openapi.core.models
 
+import com.fasterxml.jackson.annotation.JsonValue
+
 data class PrimitivesModel<T>(
+    @JsonValue
     val result: T? = null
 )

--- a/core/src/main/kotlin/org/web3j/openapi/core/models/PrimitivesModel.kt
+++ b/core/src/main/kotlin/org/web3j/openapi/core/models/PrimitivesModel.kt
@@ -12,8 +12,6 @@
  */
 package org.web3j.openapi.core.models
 
-import com.fasterxml.jackson.annotation.JsonValue
-
 data class PrimitivesModel<T>(
     val result: T? = null
 )

--- a/core/src/main/kotlin/org/web3j/openapi/core/models/PrimitivesModel.kt
+++ b/core/src/main/kotlin/org/web3j/openapi/core/models/PrimitivesModel.kt
@@ -15,6 +15,5 @@ package org.web3j.openapi.core.models
 import com.fasterxml.jackson.annotation.JsonValue
 
 data class PrimitivesModel<T>(
-    @JsonValue
     val result: T? = null
 )

--- a/core/src/main/kotlin/org/web3j/openapi/core/models/ResultModel.kt
+++ b/core/src/main/kotlin/org/web3j/openapi/core/models/ResultModel.kt
@@ -12,6 +12,6 @@
  */
 package org.web3j.openapi.core.models
 
-data class PrimitivesModel<T>(
+data class ResultModel<T>(
     val result: T? = null
 )

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.web3j.protocol" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Before, for example for a `struct`, the serialized output looks like :
```
{
         "input1" : "hi",
         "input2" : "hi
}
```
Now:
```
{
         "result: {
                    "input1" : "hi",
                     "input2" : "hi
          }
}
```

#### Reason
To have a consistent output. Currently, `Structs`, `Arrays` and `Tuples` are not put in the `result` field. However, the `Primitive types` such as `Int`, `String` have the result field. 
Now, all outputs get wrapped in a `result` field.