### PR TITLE
Forces the property names in the generated project

### DIFF
--- a/codegen/src/main/kotlin/org/web3j/openapi/codegen/utils/KPoetUtils.kt
+++ b/codegen/src/main/kotlin/org/web3j/openapi/codegen/utils/KPoetUtils.kt
@@ -12,11 +12,13 @@
  */
 package org.web3j.openapi.codegen.utils
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.AnnotationSpec
 import org.web3j.protocol.core.methods.response.AbiDefinition.NamedType
 
 internal fun List<NamedType>.toDataClass(
@@ -53,7 +55,13 @@ internal fun List<NamedType>.toDataClass(
             PropertySpec.builder(
                 inputName,
                 inputType
-            ).initializer(inputName).build()
+            ).initializer(inputName)
+                .addAnnotation(
+                    AnnotationSpec.builder(JsonProperty::class.java)
+                        .addMember("value = %S", inputName)
+                        .build()
+                )
+                .build()
         )
     }
     constructor.primaryConstructor(constructorBuilder.build())

--- a/codegen/src/test/kotlin/org/web3j/openapi/codegen/utils/KPoetUtilsTest.kt
+++ b/codegen/src/test/kotlin/org/web3j/openapi/codegen/utils/KPoetUtilsTest.kt
@@ -30,11 +30,14 @@ class KPoetUtilsTest {
         val expectedOutput = """
             package test
 
+            import com.fasterxml.jackson.annotation.JsonProperty
             import java.math.BigInteger
             import kotlin.String
 
             data class TestFunctionParameters(
+              @JsonProperty(value = "number")
               val number: BigInteger,
+              @JsonProperty(value = "string")
               val string: String
             )
             """.replace("\\s".toRegex(), "")


### PR DESCRIPTION
Uses the `JsonProperty` to handle the property names of the `inputs` in the generated project.
This solves prepending the input name with a `get` when the name starts with an `underscore (_)`.
